### PR TITLE
Fix typo in display

### DIFF
--- a/python/herc-imgtool
+++ b/python/herc-imgtool
@@ -990,7 +990,7 @@ def display_image(im):
         matplotlib.pyplot.show()
 
     except ImportError:
-        sys.stderr.write("WARNING: cannot display image ,missing matplotlib.\n")
+        sys.stderr.write("WARNING: cannot display image, missing matplotlib.\n")
 
 def do_nothing(**kwargs):
     pass


### PR DESCRIPTION
Comma placed in the correct location of warning message for matplotlib within "display".